### PR TITLE
Fix alignment for table cells with empty values

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,7 +59,9 @@ function createGroupRow(group) {
   group.series.forEach(entry => {
     serieCell.append($("<div class='result-item'></div>").text(entry.serie));
     fromCell.append($("<div class='result-item'></div>").text(entry.from));
-    toCell.append($("<div class='result-item'></div>").text(entry.to));
+
+    const toValue = entry.to || "\u00A0"; // Preserve spacing for empty values
+    toCell.append($("<div class='result-item'></div>").text(toValue));
   });
 
   row.append(serieCell, fromCell, toCell);

--- a/style.css
+++ b/style.css
@@ -91,6 +91,7 @@ td {
   text-align: left;
   padding: 10px;
   font-size: 1em;
+  vertical-align: top;
 }
 th {
   background-color: #1aaa9a;
@@ -113,6 +114,7 @@ tbody td:nth-child(2) {
 .result-item {
   padding: 2px 0;
   border-bottom: 1px solid #ddd;
+  min-height: 1.2em;
 }
 .result-item:last-child {
   border-bottom: none;


### PR DESCRIPTION
## Summary
- align table cell content to the top to keep rows consistent
- ensure each `result-item` keeps height even when empty
- keep placeholder spacing for empty "Plassering til" values

## Testing
- `jq '[.[] | select(."Plassering til:" == "")] | length' data.json`

------
https://chatgpt.com/codex/tasks/task_e_686117705e20832986d01be4fbb3b0ca